### PR TITLE
enable install with pip from github

### DIFF
--- a/csv2shex/__init__.py
+++ b/csv2shex/__init__.py
@@ -1,3 +1,4 @@
 """Generate ShEx schemas from DC Application Profiles."""
-
+from .csvshape import CSVShape, CSVTripleConstraint, CSVSchema
+from .csvreader import csvreader
 __version__ = "0.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit"]
+requires = ["setuptools!=50.0","flit"]
 build-backend = "flit.buildapi"
 
 [tool.flit.metadata]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+setup(name="csv2shex",
+  py_modules=["csv2shex"]
+  )


### PR DESCRIPTION
I wanted to install with 
`$ pip3 install -e git+https://github.com/tombaker/csv2shex.git#egg=csv2shex` 
and then import relevant classes, but there were problems.
 - problem with pip v50 described here https://github.com/pypa/setuptools/issues/2353
 - giving pip info necessary to build egg and find modules in it.

Happy to amend PR if there are elements you don't like.